### PR TITLE
After extensive debugging, we know that silent coupled with DND mode …

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -2,16 +2,8 @@
 <project version="4">
   <component name="deploymentTargetSelector">
     <selectionStates>
-      <SelectionState runConfigName="app">
+      <SelectionState runConfigName="MainActivity">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2024-09-20T09:33:50.123701100Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\tobo\.android\avd\Medium_Phone_API_35.avd" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,8 +30,7 @@
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />
             </intent-filter>
-            <meta-data android:name="android.service.quicksettings.ACTIVE_TILE"
-                android:value="true" />
+
     </service>
     </application>
 </manifest>

--- a/app/src/main/java/com/example/mutetoggles/MainActivity.kt
+++ b/app/src/main/java/com/example/mutetoggles/MainActivity.kt
@@ -11,8 +11,6 @@ import android.widget.Button
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 
 class MainActivity : AppCompatActivity() {
 
@@ -34,6 +32,7 @@ class MainActivity : AppCompatActivity() {
         val silentButton: Button = findViewById(R.id.silentButton)
         val vibrateButton: Button = findViewById(R.id.vibrateButton)
         val normalButton: Button = findViewById(R.id.normalButton)
+        val testButton: Button = findViewById(R.id.testButton)
 
         // Set an OnClickListener for the button
         myButton.setOnClickListener {
@@ -64,8 +63,18 @@ class MainActivity : AppCompatActivity() {
         }
 
         silentButton.setOnClickListener {
+          //  audioManager.ringerMode = AudioManager.RINGER_MODE_NORMAL
+            //audioManager.ringerMode = AudioManager.RINGER_MODE_SILENT
+            //notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL)
+
+            audioManager.ringerMode = AudioManager.RINGER_MODE_NORMAL // Ensure the mode is Normal
             audioManager.ringerMode = AudioManager.RINGER_MODE_SILENT
             notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL)
+            audioManager.adjustStreamVolume(
+                AudioManager.STREAM_RING,
+                AudioManager.ADJUST_MUTE,
+                0
+            )
         }
 
         vibrateButton.setOnClickListener {
@@ -74,8 +83,16 @@ class MainActivity : AppCompatActivity() {
 
         normalButton.setOnClickListener {
             audioManager.ringerMode = AudioManager.RINGER_MODE_NORMAL
+           audioManager.adjustStreamVolume(
+         AudioManager.STREAM_RING,
+               AudioManager.ADJUST_UNMUTE,
+             0
+           )
         }
 
+        testButton.setOnClickListener {
+            Toast.makeText(this, audioManager.getRingerMode().toString(), Toast.LENGTH_SHORT).show()
+        }
 
     }
 }

--- a/app/src/main/java/com/example/mutetoggles/MyQSTileService.kt
+++ b/app/src/main/java/com/example/mutetoggles/MyQSTileService.kt
@@ -56,17 +56,16 @@ class MyQSTileService : TileService() {
 
 
                     when (newRingerMode) {
-                        0 -> {
-                            audioManager.ringerMode =
+                        0 -> { audioManager.ringerMode =
                                 AudioManager.RINGER_MODE_NORMAL // Ensure the mode is Normal
                             audioManager.ringerMode = AudioManager.RINGER_MODE_SILENT
-                            notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL) //WHY DOES THIS CHANGE EL FLAGO  ?? WHY GOOGLE ???? Perhaps Race condition
+                         //   notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL) //WHY DOES THIS CHANGE EL FLAGO  ?? WHY GOOGLE ???? Perhaps Race condition
                             audioManager.adjustStreamVolume(
                                 AudioManager.STREAM_RING,
                                 AudioManager.ADJUST_MUTE,
                                 0
                             )
-                           // notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL) //THE ORDER HERE IS CRUCIAL ??? VERIFY WITH MUTEX /COROUTINES
+                            notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL) //THE ORDER HERE IS CRUCIAL ??? VERIFY WITH MUTEX /COROUTINES
                             updateTile()
                         }
 

--- a/app/src/main/java/com/example/mutetoggles/MyQSTileService.kt
+++ b/app/src/main/java/com/example/mutetoggles/MyQSTileService.kt
@@ -8,6 +8,11 @@ import android.content.IntentFilter
 import android.media.AudioManager
 import android.service.quicksettings.TileService
 import android.widget.Toast
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class MyQSTileService : TileService() {
 
@@ -18,6 +23,8 @@ class MyQSTileService : TileService() {
     private val notificationManager: NotificationManager by lazy {
         getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
     }
+
+    private val mutex = Mutex()
 
     // Called when the user adds your tile.
     override fun onTileAdded() {
@@ -39,23 +46,64 @@ class MyQSTileService : TileService() {
 
     // Called when the user taps on your tile in an active or inactive state.
     override fun onClick() {
-        // Check if Do Not Disturb access is granted
-        if (notificationManager.isNotificationPolicyAccessGranted) {
-            val ringerMode = audioManager.ringerMode
-            val newRingerMode = (ringerMode + 1) % 3  // Cycle between 0, 1, and 2
-
-            // Change the ringer mode
-            audioManager.ringerMode = newRingerMode
-
-            notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL)
+        CoroutineScope(Dispatchers.Main).launch {
+            mutex.withLock {
+                // Check if Do Not Disturb access is granted
+                if (notificationManager.isNotificationPolicyAccessGranted) {
+                    val ringerMode = audioManager.ringerMode
+                    val newRingerMode = (ringerMode + 1) % 3  // Cycle between 0, 1, and 2
 
 
-            updateTile()  // Update the tile UI
-        } else {
-            Toast.makeText(this, "Do Not Disturb Permissions are not granted.", Toast.LENGTH_SHORT).show()
+
+                    when (newRingerMode) {
+                        0 -> {
+                            audioManager.ringerMode =
+                                AudioManager.RINGER_MODE_NORMAL // Ensure the mode is Normal
+                            audioManager.ringerMode = AudioManager.RINGER_MODE_SILENT
+                            notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL) //WHY DOES THIS CHANGE EL FLAGO  ?? WHY GOOGLE ???? Perhaps Race condition
+                            audioManager.adjustStreamVolume(
+                                AudioManager.STREAM_RING,
+                                AudioManager.ADJUST_MUTE,
+                                0
+                            )
+                           // notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL) //THE ORDER HERE IS CRUCIAL ??? VERIFY WITH MUTEX /COROUTINES
+                            updateTile()
+                        }
+
+                        1 -> {
+                            audioManager.ringerMode = AudioManager.RINGER_MODE_VIBRATE
+                            updateTile()
+                        }
+
+                        2 -> {
+                            audioManager.ringerMode = AudioManager.RINGER_MODE_NORMAL
+                            audioManager.adjustStreamVolume(
+                                AudioManager.STREAM_RING,
+                                AudioManager.ADJUST_UNMUTE,
+                                0
+                            )
+                            updateTile()
+                        }
+                    }
+                }
+
+                // Change the ringer mode
+                // audioManager.ringerMode = AudioManager.RINGER_MODE_NORMAL
+                //audioManager.ringerMode = newRingerMode
+
+                // notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL)
+
+                //    updateTile()  // Update the tile UI
+                else {
+                    Toast.makeText(
+                        this@MyQSTileService,
+                        "Do Not Disturb Permissions are not granted.",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
         }
     }
-
     // Called when the user removes your tile.
     override fun onTileRemoved() {
         super.onTileRemoved()
@@ -64,8 +112,14 @@ class MyQSTileService : TileService() {
     // BroadcastReceiver to listen for ringer mode changes
     private val ringerModeReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
-            updateTile() // Update the tile when the ringer mode changes
+            CoroutineScope(Dispatchers.Main).launch {
+                mutex.withLock {
+                    updateTile() // Update the tile when the ringer mode changes
+                }
+            }
+
         }
+
     }
 
     // Function to update the Quick Settings tile UI

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,11 +8,13 @@
     tools:context=".MainActivity">
 
 
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:gravity="center"
         android:orientation="vertical"
-        android:gravity="center">
+        tools:layout_editor_absoluteX="-16dp"
+        tools:layout_editor_absoluteY="0dp">
 
         <TextView
             android:layout_width="wrap_content"
@@ -25,27 +27,36 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            app:layout_constraintTop_toTopOf="parent" />
         <!-- Button widget -->
         <Button
             android:id="@+id/myButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Grant Do Not Disturb permissions" />
+
         <Button
             android:id="@+id/silentButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Silent" />
+
         <Button
             android:id="@+id/vibrateButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Vibrate" />
+
         <Button
             android:id="@+id/normalButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Normal" />
+
+        <Button
+            android:id="@+id/testButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="test" />
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
After extensive debugging, we know that silent coupled with DND mode is a android decision.

	1. We changed the tile service from the recommended Active Mode to the standard non active mode: I do not know if there is a better way to do this, perhaps it should be investigated if for performance/battery reasons.

	2. We added a test button to the MainActivity to allow us increased testing speed.

	3. To solve the previously reported bug(related to ring mode preference), we implement two sub changes: a We explicitly set audioManager.ringerMode to RINGER_MODE_NORMAL b We implement more granular control via use of the audioManager.adjustStreamVolume method.

	4. We implemented what we learned in the QSTileService via a when loop for expediency. Now we had a new issue, during fast cycling of the tile we would hang on the normal state. During debugging it was found that the ringerMOder flag would not update reliably. We now have two hypothesis, either we have a race condition somewhere or a obscure android side-effect bug deep in the code.

	We implement a mutex, via coroutines for the onClick listener and the ringerModeReceiver.